### PR TITLE
Fix for cq_warehouse missing CSV data assets

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -8,6 +8,7 @@ block_cipher = None
 
 spyder_data = Path(site.getsitepackages()[-1]) / 'spyder'
 parso_grammar = (Path(site.getsitepackages()[-1]) / 'parso/python').glob('grammar*')
+cqw_path = Path(site.getsitepackages()[-1]) / 'cq_warehouse'
 
 if sys.platform == 'linux':
     occt_dir = os.path.join(Path(sys.prefix), 'share', 'opencascade')
@@ -26,7 +27,8 @@ a = Analysis(['run.py'],
              pathex=['.'],
              binaries=[ocp_path] + binaries1,
              datas=[(spyder_data, 'spyder'),
-                    (occt_dir, 'opencascade')] +
+                    (occt_dir, 'opencascade'),
+                    (cqw_path, 'cq_warehouse')] +
                     [(p, 'parso/python') for p in parso_grammar] + datas1,
              hiddenimports=['ipykernel.datapub', 'vtkmodules', 'vtkmodules.all',
                             'pyqtgraph.graphicsItems.ViewBox.axisCtrlTemplate_pyqt5',


### PR DESCRIPTION
When doing from cq_warehouse import * -- it complains about missing CSV files that are ignored by the github pyinstaller static build. This PR makes sure these data files are brought in to the static build.

![image](https://user-images.githubusercontent.com/16868537/191053908-1da94fc7-eead-4519-b8c2-7fdede46cef7.png)
^note this also happens when importing cq_warehouse itself (I am working on a static build that includes build123d), but wanted to share this fix