### PR TITLE
change upload-tartifact to upload-artifact

### DIFF
--- a/.github/workflows/pyinstaller-build-pip.yml
+++ b/.github/workflows/pyinstaller-build-pip.yml
@@ -45,7 +45,7 @@ jobs:
         micromamba info
         pyinstaller pyinstaller_pip.spec ${{ github.event.inputs.type }}
         cp /home/runner/work/CQ-editor/pyinstaller/CQ-editor.sh /home/runner/work/CQ-editor/dist/
-    - uses: alehechka/upload-tartifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: CQ-editor-Linux-x86_64
         path: dist
@@ -84,7 +84,7 @@ jobs:
         micromamba info
         pyinstaller pyinstaller_pip.spec ${{ github.event.inputs.type }}
         cp /Users/runner/work/CQ-editor/pyinstaller/CQ-editor.sh /Users/runner/work/CQ-editor/dist/
-    - uses: alehechka/upload-tartifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: CQ-editor-MacOS
         path: dist
@@ -120,7 +120,7 @@ jobs:
         micromamba info
         pyinstaller --debug all pyinstaller_pip.spec ${{ github.event.inputs.type }}
         Copy-Item D:\a\CQ-editor\pyinstaller\CQ-editor.cmd D:\a\CQ-editor\dist\
-    - uses: alehechka/upload-tartifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: CQ-editor-Windows
         path: dist


### PR DESCRIPTION
Workflow was named build-pip-tar because it used upload-tartifact which greatly speeds up the build process since most of the time time is spent uploading the ~10,000+ files. Using tartifact means you get a tarball inside of a zip file when you download the artifact, which is obviously not ideal for users but useful when testing since each build drops to only a few minutes.